### PR TITLE
Add flag to enable Single one shot run of vault-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The vault-init service supports the following environment variables for configur
 
 - `CHECK_INTERVAL` - The time duration between Vault health checks. ("10s")
 
+- `VAULT_INIT_ONE_SHOT` - Enable a single run of vault-init, this is useful when using auto-unsealing so to
+   exit after init is done. (false)
+
 - `GCS_BUCKET_NAME` - The Google Cloud Storage Bucket where the vault master key and root token is stored.
 
 - `KMS_KEY_ID` - The Google Cloud KMS key ID used to encrypt and decrypt the vault master key and root token.

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 		vaultRecoveryThreshold = intFromEnv("VAULT_RECOVERY_THRESHOLD", 1)
 	}
 
+	oneShotRun := boolFromEnv("VAULT_INIT_ONE_SHOT", false)
 	checkInterval := durFromEnv("CHECK_INTERVAL", 10*time.Second)
 
 	gcsBucketName = os.Getenv("GCS_BUCKET_NAME")
@@ -193,6 +194,11 @@ func main() {
 			}
 		default:
 			log.Printf("Vault is in an unknown state. Status code: %d", response.StatusCode)
+		}
+
+		if oneShotRun {
+			log.Printf("Single run of vault-init requested. Exiting")
+			stop()
 		}
 
 		log.Printf("Next check in %s", checkInterval)


### PR DESCRIPTION
When using auto-unsealing all we need is for the INIT to happen. 
After that we don't need the vault-init process to loop forever without ever doing any action.

Setting "VAULT_INIT_ONE_SHOT=true" in the environment will cause vault-init to exit after the first loop. 

